### PR TITLE
Add missing footer line

### DIFF
--- a/key-intercept.el
+++ b/key-intercept.el
@@ -292,3 +292,4 @@ sepcified key."
   (define-modal-intercept-key key nil def delay))
 
 (provide 'key-intercept)
+;;; key-intercept.el ends here


### PR DESCRIPTION
For the following MELPA registration, we need to add the footer line to `key-intercept.el`.

https://github.com/milkypostman/melpa/pull/1469
